### PR TITLE
Better title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,6 @@
 # Site settings
 title: devanooga
+tagline: "A community of tinkerers in and around Chattanooga, TN"
 url: "https://devanooga.com"
 twitter_username: devanooga
 github_username:  devanooga

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+  <title>{% if page.title %}{{ page.title }}: {{ site.title }}{% else %}{{ site.title }}: {{ site.tagline }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
Added a `tagline` site variable which is now used on the home page title. Added the `site.title` variable to the child page titles.

Added some formatting to the document titles, too:
`site.title: site.tagline`
`page.title: site.title`