### PR TITLE
WIP: First stab at home page (about) content

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ layout: default
   <section>
     <h2>About devanooga</h2>
     <p>devanooga is an online resource for folks who like to tinker with technology in and around the Chattanooga area. Our organization is still young and far from fleshed out, and we want to hear your thoughts and ideas.</p>
-    <p>Get in touch with us to learn more about how you can help shape this community.</p>
+    <p><a href="/contact/">Get in touch with us</a> to learn more about how you can help shape this community.</p>
 
     <h2>Our resources</h2>
     <p>Our main resource is a <a href="/slack/">Slack Org</a>, where technologists from all around the region come together to share ideas, troubleshoot their projects, learn new things, or just hang out. We keep a relaxed atmosphere in there, but we do expect you to heed our <a href="/coc/">Code of Conduct</a> (CoC). If you have any questions about the CoC, feel free to ask us on Slack, either publicly in the #general channel, or privately to any of the admins.</p>

--- a/index.html
+++ b/index.html
@@ -14,6 +14,6 @@ layout: default
     <p><a href="/contact/">Get in touch with us</a> to learn more about how you can help shape this community.</p>
 
     <h2>Our resources</h2>
-    <p>Our main resource is a <a href="/slack/">Slack Org</a>, where technologists from all around the region come together to share ideas, troubleshoot their projects, learn new things, or just hang out. We keep a relaxed atmosphere in there, but we do expect you to heed our <a href="/coc/">Code of Conduct</a> (CoC). If you have any questions about the CoC, feel free to ask us on Slack, either publicly in the #general channel, or privately to any of the admins.</p>
+    <p>Our main resource is a <a href="/slack/">Slack Team</a>, where technologists from all around the region come together to share ideas, troubleshoot their projects, learn new things, or just hang out. We keep a relaxed atmosphere in there, but we do expect you to heed our <a href="/coc/">Code of Conduct</a> (CoC). If you have any questions about the CoC, feel free to <a href="/contact/">use our contact form</a> to get in touch. You can also ask us on Slack, either publicly in the #general channel, or privately to any of the admins.</p>
   </section>
 </div>

--- a/index.html
+++ b/index.html
@@ -3,5 +3,17 @@ layout: default
 ---
 
 <div class="home">
+  <header>
+    <p>We are an online community of tinkerers in and around Chattanooga, TN.</p>
+    <p><a href="/slack/">Join us on Slack.</a></p>
+  </header>
 
+  <section>
+    <h2>About devanooga</h2>
+    <p>devanooga is an online resource for folks who like to tinker with technology in and around the Chattanooga area. Our organization is still young and far from fleshed out, and we want to hear your thoughts and ideas.</p>
+    <p>Get in touch with us to learn more about how you can help shape this community.</p>
+
+    <h2>Our resources</h2>
+    <p>Our main resource is a <a href="/slack/">Slack Org</a>, where technologists from all around the region come together to share ideas, troubleshoot their projects, learn new things, or just hang out. We keep a relaxed atmosphere in there, but we do expect you to heed our <a href="/coc/">Code of Conduct</a> (CoC). If you have any questions about the CoC, feel free to ask us on Slack, either publicly in the #general channel, or privately to any of the admins.</p>
+  </section>
 </div>


### PR DESCRIPTION
Fixes #5 *Not ready to merge yet.*

Would like some feedback on this copy. Also, where would we link the _Get in touch with us_ bit in the About section? Are we gonna have a contact page with a form and/or contact details, or should we change the language to direct people to our Slack community?

I’d like for there to be a way for folks to get in touch outside of Slack, but I also realize that creates Yet Another Noise Channel for whoever will receive notifications for that (email, contact form submissions, whatever). Maybe a contact form that uses a webhook to post submissions to a private Slack channel?