### PR TITLE
Unfuck back button on mobile

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -20,4 +20,11 @@
     container.appendChild(nav);
     header.className += ' enhanced';
   })(window, document);
+
+  (function (window, document) {
+    var close_button = document.getElementsByClassName('navigation--close')[0];
+    close_button.addEventListener('click', function go_back (event) {
+      window.history.back();
+    });
+  })(window, document);
 </script>


### PR DESCRIPTION
Nav close link invokes `window.history.back()` instead of simply pointing to a different target. Users who can’t run JS are still left with less than ideal behavior.