### PR TITLE
Remove border from linked member image

### DIFF
--- a/_sass/_members.scss
+++ b/_sass/_members.scss
@@ -27,6 +27,7 @@
   img {
     width: 100%;
     display: block;
+    border: none;
   }
   a.website {
     position: relative;


### PR DESCRIPTION
I closed this PR from @StrangeWill’s repo. Submitting it here instead. It’s a small IE-specific fix.